### PR TITLE
fix(canton-templating): purge plaintext secrets-clear.yaml after SOPS encryption [SRE-1540]

### DIFF
--- a/kubernetes/canton-templating.py
+++ b/kubernetes/canton-templating.py
@@ -392,9 +392,13 @@ def process_directory(src_dir, dest_dir, env_file, debug=False, alias_prefix=Fal
                             else:
                                 logging.error(f"SOPS encryption failed for {dest_file}: {sops_result.stderr.strip()}")
                                 print(f"[ERROR] SOPS encryption failed for {dest_file}: {sops_result.stderr.strip()}")
-                        # Add secrets-clear.yaml to .gitignore
-                        relative_file_path = os.path.relpath(dest_file, dest_dir)
-                        symlink_targets.add(relative_file_path)
+                        # The SOPS-encrypted secrets.yaml is the committed artifact; the rendered
+                        # plaintext secrets-clear.yaml is a throwaway intermediate. Purge it so no
+                        # plaintext secret ever lingers on disk (it is re-rendered on the next run).
+                        # It is therefore NOT added to .gitignore — there is nothing to ignore.
+                        if os.path.isfile(dest_file):
+                            os.remove(dest_file)
+                            logging.debug(f"Removed plaintext intermediate: {dest_file}")
                     elif file in ('Chart.yaml', 'values.yaml'):
                         logging.debug(f"Processing {file} at {src_file} without alias prefix")
                         process_yaml_content(src_file, dest_path=dest_file, env_vars=env_vars)


### PR DESCRIPTION
## SRE-1540 — stop leaving plaintext secrets on disk

`process_directory` renders `secrets-clear.yaml` (plaintext), SOPS-encrypts it into `secrets.yaml` (the
committed artifact), then **previously kept the plaintext on disk and added it to `.gitignore`**. That
`.gitignore` entry only existed to stop a plaintext-secret file from being committed — a workaround for a
file that should never persist.

### Change
After encryption, `os.remove()` the plaintext intermediate and stop adding it to the generated
`.gitignore`. The plaintext now exists only transiently during a run and is re-rendered from the template
+ JSON each time. The change-gated re-encryption (decrypt existing `secrets.yaml`, compare, skip if equal)
is untouched, so there is no `secrets.yaml` churn.

### Effect on consumers
Regenerating `kubernetes-deployments` (companion PR for SRE-1540) purges all 30 env-dir plaintext
`secrets-clear.yaml` files and drops the stale entries from every `canton-val-*/.gitignore`. Verified:
0 plaintext on disk afterwards, no `secrets.yaml` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)